### PR TITLE
fix the infinite scroller

### DIFF
--- a/src/components/organisms/ImageFooterDetails/ImageFooterDetails.js
+++ b/src/components/organisms/ImageFooterDetails/ImageFooterDetails.js
@@ -12,7 +12,7 @@ const ImagesFooterDetails = ({
 			<p className='image-description'>{description}</p>
 			<div className='flex-center'>
 				<HeartIcon />
-				<div class="likes">{likes}</div>
+				<div className="likes">{likes}</div>
 			</div>
 		</div>
 	)

--- a/src/components/pages/ImagesGallery/ImagesGallery.js
+++ b/src/components/pages/ImagesGallery/ImagesGallery.js
@@ -10,14 +10,13 @@ const endMessage = (<p style={{ textAlign: 'center' }}>
 
 const ImagesGallery = ({
 	images,
-	totalImages,
 	fetchImages,
 	isAllItemsLoaded
 }) => {
 
 	return (
 		<InfiniteScroll
-			dataLength={totalImages}
+			dataLength={images.length}
 			next={fetchImages}
 			hasMore={!isAllItemsLoaded}
 			loader={<h4>Loading...</h4>}

--- a/src/components/pages/ImagesGallery/ImagesGalleryContainer.js
+++ b/src/components/pages/ImagesGallery/ImagesGalleryContainer.js
@@ -10,26 +10,31 @@ const ImagesGalleryContainer = ({ imagesStore }) => {
 	const [page, updatePage] = useState(DEFAULT_PAGINATION_PAGE);
 	const [isAllItemsLoaded, stopScroller] = useState(false);
 
-	const fetchImagesGallery = async () => {
-		const response = await imagesStore.fetchImagesList({ page });
-		const newList = [
-			...imagesList,
-			...response
-		]
-		setImagesList(newList);
+	const fetchImagesGalleryOnce = async () => {
+
+		const response = await imagesStore.fetchAllImagesList();
+
+		setImagesList(response);
+
+		updatePage(page + DEFAULT_PAGINATION_PAGE);
+	}
+
+	const fetchMoreImages = () => {
+		const response = imagesStore.getNextImages({ page });
+		setImagesList(response);
 
 		updatePage(page + DEFAULT_PAGINATION_PAGE);
 
-		if (newList.length === imagesStore.images.length) stopScroller(true);
+		if (response.length >= imagesStore.images.length) stopScroller(true);
 	}
 
 	useEffect(() => {
-		fetchImagesGallery();
+		fetchImagesGalleryOnce();
 	}, []);
 	
 	return (
-		<div className='images-gallery-container'>
-			<ImagesGallery images={imagesList} fetchImages={fetchImagesGallery} totalImages={imagesStore.images.length} isAllItemsLoaded={isAllItemsLoaded} />
+		<div className='images-gallery-container' id='images-gallery'>
+			<ImagesGallery images={imagesList} fetchImages={fetchMoreImages} totalImages={imagesStore.images.length} isAllItemsLoaded={isAllItemsLoaded} />
 		</div>
 	)
 }

--- a/src/stores/ImagesStore.js
+++ b/src/stores/ImagesStore.js
@@ -5,18 +5,16 @@ class ImagesStore {
 		this.images = [];
 	}
 
-	loadImagesByPagination = async (pagination) => {
+	loadImagesByPagination = (pagination) => {
 		const { page = DEFAULT_PAGINATION_PAGE, size = PAGINATION_SIZE } = pagination;
 		const totalImages = this.images.length;
 
 		if (page * size >= totalImages) return this.images;
 
-		return this.images.slice(page * size - size, page * size);
+		return this.images.slice(0, page * size);
 	}
 
-	fetchImagesList = async (pagination = {}) => {
-		if (this.images.length > 0) return this.loadImagesByPagination(pagination);
-
+	fetchAllImagesList = async () => {
 		const result = await fetch('/api/images')
 			.then(res => res.json())
 
@@ -25,31 +23,10 @@ class ImagesStore {
 		return this.loadImagesByPagination({ page: DEFAULT_PAGINATION_PAGE, size: PAGINATION_SIZE });
 	}
 
+	getNextImages = (pagination) => {
+		return this.loadImagesByPagination(pagination);
+	}
+
 }
 
 export default ImagesStore;
-
-// const ImagesStore = {
-// 	images: [],
-
-// 	loadImagesByPagination: async (pagination) => {
-// 		const { page = DEFAULT_PAGINATION_PAGE, size = PAGINATION_SIZE } = pagination;
-// 		const totalImages = ImagesStore.images.length;
-
-// 		if (page * size > totalImages) return ImagesStore.images;
-
-// 		return ImagesStore.images.slice(page * size - size, page * size);
-// 	},
-
-// 	fetchImagesList: async (pagination = {}) => {
-// 		if (ImagesStore.images.length > 0) return ImagesStore.loadImagesByPagination(pagination);
-
-// 		const result = await fetch('/api/images')
-// 			.then(res => res.json())
-
-// 		ImagesStore.images = result.data;
-// 		return ImagesStore.loadImagesByPagination({ page: DEFAULT_PAGINATION_PAGE, size: PAGINATION_SIZE });
-// 	}
-// }
-
-// export default ImagesStore;


### PR DESCRIPTION
- Fix infinite scroller issue - should give him the rendered images length and not the length of the total images.

- rename class to className

- Split images loading to two methods -> one for initiate the images cache, second for fetching more images like pagination.
